### PR TITLE
change Store3x2 prefab so it gets placed next to the road, not on top.

### DIFF
--- a/Assets/Prefabs/Buildings/Store3x2.prefab
+++ b/Assets/Prefabs/Buildings/Store3x2.prefab
@@ -76,7 +76,7 @@ Transform:
   m_GameObject: {fileID: 4187876269468952044}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 1.034, y: 0.509, z: 0.55200005}
-  m_LocalScale: {x: 0.7127979, y: 0.52512, z: 0.44417801}
+  m_LocalScale: {x: 0.7127979, y: 0.52512, z: -0.444178}
   m_Children: []
   m_Father: {fileID: 2029309241569372354}
   m_RootOrder: 0
@@ -156,7 +156,7 @@ Transform:
   m_GameObject: {fileID: 5488636737170311293}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.5, y: 0, z: 0.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: -1}
   m_Children:
   - {fileID: 9020720869732572418}
   m_Father: {fileID: 4077273949542292765}


### PR DESCRIPTION
While placing Store3x2, I could not place it next to the road, only on top of the road. Flipping the prefab along the z-axis seemed to fix it.

Before:
<img width="430" alt="Screen Shot 2020-02-19 at 8 26 59 pm" src="https://user-images.githubusercontent.com/22112320/74825232-b01d5e00-535d-11ea-98a5-b14b1690c786.png">

After:
<img width="510" alt="Screen Shot 2020-02-19 at 9 21 16 pm" src="https://user-images.githubusercontent.com/22112320/74825304-cd522c80-535d-11ea-8fdb-eea014e8dd9b.png">


(Also, hello! The Unity version looks so much easier to work with! Good call switching over. )
